### PR TITLE
Restrict workflow to 'main' and remove PR trigger

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,10 +2,8 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: [ "main", "master" ]
+    branches: [ "main" ]
     tags: [ "v*.*.*" ]
-  pull_request:
-    branches: [ "main", "master" ]
 
 jobs:
   build:


### PR DESCRIPTION
Update CI workflow to only run on pushes to the main branch and semver tags. Removed the legacy 'master' branch from the push filter and deleted the pull_request trigger to avoid duplicate/undesired runs.