### PR TITLE
feat: integrate Orion visual into chatbot and hero section

### DIFF
--- a/components/PathfinderChat.vue
+++ b/components/PathfinderChat.vue
@@ -69,6 +69,9 @@
           <div class="pathfinder-welcome-planet" aria-hidden="true">
             <img src="/orion.webp" alt="Admiral Orion" class="pathfinder-welcome-avatar" />
           </div>
+          <div class="pathfinder-welcome-orion">
+            <img src="/orion.webp" alt="Admiral Orion" />
+          </div>
           <p class="text-sm font-semibold mb-1">Welcome aboard, Cadet!</p>
           <p class="text-xs opacity-60 leading-relaxed">Admiral Orion at your command. Report your inquiries about our mission, principles, learning paths, and fleet operations.</p>
           <div class="pathfinder-suggestions">
@@ -812,6 +815,26 @@ onUnmounted(() => {
 .pathfinder-slide-leave-to {
   opacity: 0;
   transform: translateY(24px) scale(0.92);
+}
+
+.pathfinder-welcome-orion {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 0.75rem;
+}
+
+.pathfinder-welcome-orion img {
+  width: 180px;
+  height: 144px;
+  object-fit: cover;
+  border-radius: 16px;
+
+  border: 1px solid rgba(255, 107, 53, 0.4);
+
+  box-shadow: 
+    0 0 20px rgba(255, 107, 53, 0.3);
+
+  animation: pathfinder-orbit-bob 5s ease-in-out infinite;
 }
 
 /* Mobile responsive */

--- a/components/PathfinderChat.vue
+++ b/components/PathfinderChat.vue
@@ -28,7 +28,6 @@
       <div class="pathfinder-header">
         <div class="flex items-center gap-2">
           <!-- Admiral Orion avatar -->
-          <img src="/orion.webp" alt="Admiral Orion" class="pathfinder-header-avatar" />
           <div class="flex flex-col leading-tight">
             <span class="font-bold text-sm pathfinder-title-text">Admiral Orion</span>
             <span class="text-[10px] opacity-50 tracking-wide">FLEET COMMANDER</span>
@@ -66,9 +65,6 @@
       <div ref="messagesContainer" class="pathfinder-messages">
         <!-- Welcome screen -->
         <div v-if="history.length === 0" class="pathfinder-welcome">
-          <div class="pathfinder-welcome-planet" aria-hidden="true">
-            <img src="/orion.webp" alt="Admiral Orion" class="pathfinder-welcome-avatar" />
-          </div>
           <div class="pathfinder-welcome-orion">
             <img src="/orion.webp" alt="Admiral Orion" />
           </div>

--- a/pages/admiral-orion.vue
+++ b/pages/admiral-orion.vue
@@ -3,10 +3,7 @@
     <!-- Hero Section -->
     <section class="hero">
       <div class="hero-content">
-        <div class="admiral-badge" aria-hidden="true">
-          <img src="/orion.webp" alt="Admiral Orion" class="admiral-avatar-img" />
-        </div>
-                  <div class="orion-visual">
+        <div class="orion-visual">
             <img 
               src="/orion.webp" 
               alt="Admiral Orion"

--- a/pages/admiral-orion.vue
+++ b/pages/admiral-orion.vue
@@ -6,6 +6,13 @@
         <div class="admiral-badge" aria-hidden="true">
           <img src="/orion.webp" alt="Admiral Orion" class="admiral-avatar-img" />
         </div>
+                  <div class="orion-visual">
+            <img 
+              src="/orion.webp" 
+              alt="Admiral Orion"
+              class="orion-image"
+            />
+        </div>
         <h1>Meet Admiral Orion</h1>
         <p class="tagline">Your AI-Powered Guide to the Skill-Wanderer Universe</p>
         <p class="hero-description">
@@ -412,6 +419,32 @@ function askQuestion(question: string) {
   background: rgba(255, 107, 53, 0.18);
   border-color: var(--primary-orange);
   transform: translateY(-2px);
+}
+
+.orion-visual {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+  animation: fadeInUp 0.8s ease-out 0.1s both;
+}
+
+.orion-image {
+  width: 900px;
+  height: 600px;
+  object-fit: cover;
+
+  /* Ubah jadi persegi rounded (bukan lingkaran) */
+  border-radius: 16px;
+
+  /* Frame feel (lebih "panel AI") */
+  border: 1px solid rgba(255, 107, 53, 0.4);
+
+  /* Glow subtle */
+  box-shadow: 
+    0 10px 30px rgba(0, 0, 0, 0.4),
+    0 0 20px rgba(255, 107, 53, 0.2);
+
+  transition: all 0.3s ease;
 }
 
 /* Animations */


### PR DESCRIPTION
## Summary
- Integrate Orion visual into hero section (landing page)
- Replace chatbot welcome icon with Orion image
- Replace assistant avatar with Orion identity

## UI/UX Impact
- Strengthens AI identity (Orion as entity, not just icon)
- Improves visual hierarchy and user engagement
- More immersive chatbot experience

## Technical Notes
- No breaking changes
- Pure frontend/UI enhancement
- Uses existing public asset (`/orion.webp`)

## Testing
- Verified on local development
- Chatbot interaction works as expected
- Responsive layout preserved