### PR TITLE
fix: open dojo and blog links in new tab in footer

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -5,8 +5,8 @@
         <NuxtLink to="/about">About</NuxtLink>
         <NuxtLink to="/principles">Guild Principles</NuxtLink>
         <NuxtLink to="/work-with-us">Engage the Guild</NuxtLink>
-        <NuxtLink to="https://dojo.skill-wanderer.com">Dojo</NuxtLink>
-        <NuxtLink to="https://wanderings.skill-wanderer.com">Blog</NuxtLink>
+        <a href="https://dojo.skill-wanderer.com" target="_blank" rel="noopener noreferrer">Dojo</a>
+        <a href="https://wanderings.skill-wanderer.com" target="_blank" rel="noopener noreferrer">Blog</a>
         <a href="https://linkedin.com/company/skill-wanderer" target="_blank" rel="noopener noreferrer">Company LinkedIn</a>
         <NuxtLink to="/contact">Contact</NuxtLink>
         <NuxtLink to="/privacy-policy">Privacy Policy</NuxtLink>


### PR DESCRIPTION
## Summary
- Updated footer Dojo and Blog links to use external anchors
- Added `target="_blank"` and `rel="noopener noreferrer"` for consistency with the Guild Ecosystem dropdown

## Test
- yarn typecheck
- Manually verified footer Dojo and Blog open in a new tab