### PR TITLE
fix: resolve production newsletter subscription runtimeConfig drift

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -65,6 +65,8 @@ export default defineNuxtConfig({
   },
 
   runtimeConfig: {
+    resendApiKey: process.env.NUXT_RESEND_API_KEY || process.env.RESEND_API_KEY || '',
+    resendFromEmail: process.env.NUXT_RESEND_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || '',
     public: {
       firebase: {
         apiKey: process.env.NUXT_PUBLIC_FIREBASE_API_KEY || 'AIzaSyCr_1Fo6hzJDsKZrjw2u3HlrFhBnfeHmxE',


### PR DESCRIPTION
## Root Cause

Production runtimeConfig did not map NUXT_RESEND_* variables, causing /api/subscribe to fall through to the 503 guard despite valid deployment envs.

## Fix

* mapped NUXT_RESEND_API_KEY
* mapped NUXT_RESEND_FROM_EMAIL
* preserved legacy RESEND_* fallback
* preserved backend-owned subscription architecture

## Validation

* npm run typecheck ✅
* npm run build ✅
* local production-style env validation ✅
* Resend delivery validation ✅
* real inbox delivery validation ✅

## Blast Radius

Limited to:

* nuxt.config.ts

No frontend behavior changes.
No API contract changes.
No provider lifecycle changes.