### PR TITLE
fix: harden newsletter subscribe workflow and runtime resilience

### DIFF
--- a/components/TheSubscribe.vue
+++ b/components/TheSubscribe.vue
@@ -162,19 +162,19 @@ const restorePendingRequestNotice = () => {
   }
 }
 
-onMounted(() => {
-  const handlePageHide = () => {
-    isPageUnloading.value = true
-  }
+const handlePageHide = () => {
+  isPageUnloading.value = true
+}
 
+onMounted(() => {
   window.addEventListener('pagehide', handlePageHide)
   window.addEventListener('beforeunload', handlePageHide)
   restorePendingRequestNotice()
+})
 
-  onBeforeUnmount(() => {
-    window.removeEventListener('pagehide', handlePageHide)
-    window.removeEventListener('beforeunload', handlePageHide)
-  })
+onBeforeUnmount(() => {
+  window.removeEventListener('pagehide', handlePageHide)
+  window.removeEventListener('beforeunload', handlePageHide)
 })
 
 const handleSubscribe = async () => {

--- a/components/TheSubscribe.vue
+++ b/components/TheSubscribe.vue
@@ -7,17 +7,22 @@
         
         <form @submit.prevent="handleSubscribe" class="subscribe-form">
           <div class="input-group">
+            <label class="sr-only" for="subscribe-email">Email address</label>
             <input
               v-model="email"
+              id="subscribe-email"
               type="email"
               placeholder="Enter your email address"
+              autocomplete="email"
+              inputmode="email"
+              maxlength="254"
               required
               :disabled="isSubmitting"
               class="email-input"
             />
             <button
               type="submit"
-              :disabled="isSubmitting || !email"
+              :disabled="isSubmitting || !trimmedEmail"
               class="subscribe-btn"
             >
               <span v-if="!isSubmitting">Subscribe</span>
@@ -26,7 +31,12 @@
           </div>
         </form>
 
-        <div v-if="message" :class="['message', messageType]">
+        <div
+          v-if="message"
+          :class="['message', messageType]"
+          role="status"
+          :aria-live="messageType === 'error' ? 'assertive' : 'polite'"
+        >
           {{ message }}
         </div>
 
@@ -39,19 +49,150 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import type { SubscribeResponse } from '~/types'
+
+const SUBSCRIBE_REQUEST_TIMEOUT_MS = 10_000
+const SUBSCRIBE_PENDING_STORAGE_KEY = 'skill-wanderer:subscribe-pending'
+const SUBSCRIBE_PENDING_NOTICE_WINDOW_MS = 30_000
 
 const email = ref('')
 const isSubmitting = ref(false)
 const message = ref('')
-const messageType = ref<'success' | 'error'>('success')
+const messageType = ref<'success' | 'error' | 'info'>('success')
+const isPageUnloading = ref(false)
+const route = useRoute()
+
+const trimmedEmail = computed(() => email.value.trim())
+const subscribeSource = computed<'home' | 'contact'>(() => (route.path === '/contact' ? 'contact' : 'home'))
+
+const getRequestReference = (requestId: string) => requestId.split('-')[0] || requestId
+
+const formatFailureMessage = (baseMessage: string, requestId?: string, retryAfterSeconds?: number) => {
+  const retryMessage = typeof retryAfterSeconds === 'number'
+    ? ` Try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`
+    : ''
+  const referenceMessage = requestId ? ` Reference: ${getRequestReference(requestId)}.` : ''
+
+  return `${baseMessage}${retryMessage}${referenceMessage}`.trim()
+}
+
+const isSubscribeResponse = (value: unknown): value is SubscribeResponse => {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const payload = value as {
+    ok?: unknown
+    status?: unknown
+    message?: unknown
+    requestId?: unknown
+    retryAfterSeconds?: unknown
+  }
+
+  if (typeof payload.ok !== 'boolean' || typeof payload.status !== 'string' || typeof payload.message !== 'string' || typeof payload.requestId !== 'string') {
+    return false
+  }
+
+  if (payload.ok) {
+    return payload.status === 'accepted' || payload.status === 'confirmed'
+  }
+
+  const validFailureStatuses = new Set(['invalid', 'throttled', 'unavailable', 'failed'])
+
+  return validFailureStatuses.has(payload.status)
+    && (payload.retryAfterSeconds === undefined || typeof payload.retryAfterSeconds === 'number')
+}
+
+const readSubscribeResponse = async (response: Response) => {
+  const contentType = response.headers.get('content-type') || ''
+
+  if (!contentType.includes('application/json')) {
+    return null
+  }
+
+  const payload = await response.json() as unknown
+  return isSubscribeResponse(payload) ? payload : null
+}
+
+const setPendingRequestMarker = () => {
+  if (!import.meta.client) {
+    return
+  }
+
+  window.sessionStorage.setItem(
+    SUBSCRIBE_PENDING_STORAGE_KEY,
+    JSON.stringify({
+      startedAt: Date.now(),
+      source: subscribeSource.value
+    })
+  )
+}
+
+const clearPendingRequestMarker = () => {
+  if (!import.meta.client) {
+    return
+  }
+
+  window.sessionStorage.removeItem(SUBSCRIBE_PENDING_STORAGE_KEY)
+}
+
+const restorePendingRequestNotice = () => {
+  if (!import.meta.client) {
+    return
+  }
+
+  const rawValue = window.sessionStorage.getItem(SUBSCRIBE_PENDING_STORAGE_KEY)
+
+  if (!rawValue) {
+    return
+  }
+
+  clearPendingRequestMarker()
+
+  try {
+    const payload = JSON.parse(rawValue) as { startedAt?: number }
+
+    if (typeof payload.startedAt === 'number' && Date.now() - payload.startedAt <= SUBSCRIBE_PENDING_NOTICE_WINDOW_MS) {
+      message.value = 'A previous subscription request may still be processing. If you do not receive a confirmation email shortly, you can try again.'
+      messageType.value = 'info'
+    }
+  } catch {
+    // Ignore unreadable pending state.
+  }
+}
+
+onMounted(() => {
+  const handlePageHide = () => {
+    isPageUnloading.value = true
+  }
+
+  window.addEventListener('pagehide', handlePageHide)
+  window.addEventListener('beforeunload', handlePageHide)
+  restorePendingRequestNotice()
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('pagehide', handlePageHide)
+    window.removeEventListener('beforeunload', handlePageHide)
+  })
+})
 
 const handleSubscribe = async () => {
-  if (!email.value || isSubmitting.value) return
+  const normalizedEmail = trimmedEmail.value
 
+  if (!normalizedEmail || isSubmitting.value) return
+
+  isPageUnloading.value = false
   isSubmitting.value = true
   message.value = ''
+  setPendingRequestMarker()
+
+  const controller = new AbortController()
+  let didTimeout = false
+  const timeoutId = window.setTimeout(() => {
+    didTimeout = true
+    controller.abort()
+  }, SUBSCRIBE_REQUEST_TIMEOUT_MS)
 
   try {
     const response = await fetch('/api/subscribe', {
@@ -59,26 +200,56 @@ const handleSubscribe = async () => {
       headers: {
         'Content-Type': 'application/json'
       },
+      signal: controller.signal,
       body: JSON.stringify({
-        email: email.value
+        email: normalizedEmail,
+        source: subscribeSource.value
       })
     })
 
-    const result = await response.json() as SubscribeResponse
+    const requestId = response.headers.get('x-request-id') || undefined
+    const result = await readSubscribeResponse(response)
 
-    if (!response.ok || !result.success) {
-      message.value = result.success ? 'Something went wrong. Please try again.' : result.message
+    if (!result) {
+      message.value = formatFailureMessage('Subscription service returned an unexpected response.', requestId)
       messageType.value = 'error'
       return
     }
 
-    message.value = 'Thanks for subscribing! We\'ll keep you updated.'
-    messageType.value = 'success'
-    email.value = ''
+    if (result.ok && result.status === 'confirmed') {
+      message.value = result.message
+      messageType.value = 'success'
+      email.value = ''
+      return
+    }
+
+    if (result.ok && result.status === 'accepted') {
+      message.value = result.message
+      messageType.value = 'info'
+      email.value = ''
+      return
+    }
+
+    if (!result.ok) {
+      message.value = formatFailureMessage(result.message, result.requestId, result.retryAfterSeconds)
+      messageType.value = 'error'
+      return
+    }
+
+    message.value = formatFailureMessage('Subscription service returned an unexpected response.', result.requestId)
+    messageType.value = 'error'
   } catch {
-    message.value = 'Something went wrong. Please try again.'
+    message.value = didTimeout
+      ? 'Subscription is taking longer than expected. Please try again in a moment.'
+      : 'Something went wrong. Please try again.'
     messageType.value = 'error'
   } finally {
+    window.clearTimeout(timeoutId)
+
+    if (!isPageUnloading.value) {
+      clearPendingRequestMarker()
+    }
+
     isSubmitting.value = false
   }
 }
@@ -189,10 +360,28 @@ const handleSubscribe = async () => {
   border: 1px solid rgba(34, 197, 94, 0.3);
 }
 
+.message.info {
+  background: rgba(59, 130, 246, 0.1);
+  color: #60a5fa;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+}
+
 .message.error {
   background: rgba(239, 68, 68, 0.1);
   color: #ef4444;
   border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .privacy-note {

--- a/server/api/subscribe.post.ts
+++ b/server/api/subscribe.post.ts
@@ -1,18 +1,31 @@
 import { Resend } from 'resend'
-import { getHeader } from 'h3'
+import { getHeader, setResponseHeader } from 'h3'
 import type { H3Event } from 'h3'
 import type { SubscribeRequest, SubscribeResponse } from '~/types'
 import { createSubscriptionConfirmationEmail } from '~/server/services/email/subscription'
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const MAX_EMAIL_LENGTH = 254
+const REQUEST_ID_HEADER = 'X-Request-Id'
+const SUBSCRIBE_STATUS_HEADER = 'X-Subscribe-Status'
+const SUBSCRIBE_CODE_HEADER = 'X-Subscribe-Code'
+const SUBSCRIBE_DURATION_HEADER = 'X-Subscribe-Duration-Ms'
+const CACHE_CONTROL_HEADER = 'Cache-Control'
+const CACHE_CONTROL_VALUE = 'no-store'
+const RETRY_AFTER_HEADER = 'Retry-After'
 const SUBSCRIPTION_UNAVAILABLE_MESSAGE = 'Subscription service is temporarily unavailable.'
 const SUBSCRIPTION_FAILED_MESSAGE = 'Something went wrong. Please try again.'
 const SUBSCRIPTION_THROTTLED_MESSAGE = 'Please wait before trying again.'
 const RESEND_API_KEY_PLACEHOLDER = 'YOUR_RESEND_API_KEY'
 const SUBSCRIPTION_THROTTLE_WINDOW_MS = 60_000
 const SUBSCRIPTION_IDEMPOTENCY_PREFIX = 'skill-wanderer-subscribe'
+const SUBSCRIBE_ACCEPTED_MESSAGE = 'We received your request and sent a confirmation email. Please check your inbox.'
 
 const subscriptionThrottle = new Map<string, number>()
+
+type SubscribeFailureResponse = Extract<SubscribeResponse, { ok: false }>
+type SubscribeSuccessResponse = Extract<SubscribeResponse, { ok: true }>
+type SubscribeLogLevel = 'info' | 'warn' | 'error'
 
 const maskEmail = (email: string) => {
   const [localPart = '', domain = ''] = email.split('@')
@@ -45,6 +58,8 @@ const pruneExpiredThrottleEntries = (now: number) => {
 const getRetryAfterMs = (now: number, lastAttemptAt: number) =>
   Math.max(SUBSCRIPTION_THROTTLE_WINDOW_MS - (now - lastAttemptAt), 0)
 
+const toRetryAfterSeconds = (retryAfterMs: number) => Math.max(Math.ceil(retryAfterMs / 1000), 1)
+
 const encodeHex = (buffer: ArrayBuffer) =>
   Array.from(new Uint8Array(buffer), (byte) => byte.toString(16).padStart(2, '0')).join('')
 
@@ -56,46 +71,258 @@ const createSubscriptionIdempotencyKey = async (email: string) => {
 }
 
 const pickRuntimeString = (...values: unknown[]) =>
-  values.find((value): value is string => typeof value === 'string' && value.length > 0)
+  values.find((value): value is string => typeof value === 'string' && value.trim().length > 0)?.trim()
+
+const createRequestId = () => globalThis.crypto.randomUUID()
+
+const setResponseMetadata = (
+  event: H3Event,
+  requestId: string,
+  status: SubscribeResponse['status'],
+  durationMs: number,
+  code?: SubscribeFailureResponse['code'],
+  retryAfterSeconds?: number
+) => {
+  setResponseHeader(event, CACHE_CONTROL_HEADER, CACHE_CONTROL_VALUE)
+  setResponseHeader(event, REQUEST_ID_HEADER, requestId)
+  setResponseHeader(event, SUBSCRIBE_STATUS_HEADER, status)
+  setResponseHeader(event, SUBSCRIBE_DURATION_HEADER, String(durationMs))
+
+  if (code) {
+    setResponseHeader(event, SUBSCRIBE_CODE_HEADER, code)
+  }
+
+  if (typeof retryAfterSeconds === 'number') {
+    setResponseHeader(event, RETRY_AFTER_HEADER, retryAfterSeconds)
+  }
+}
+
+const logSubscribeEvent = (
+  level: SubscribeLogLevel,
+  payload: Record<string, string | number | boolean | undefined>
+) => {
+  const entry = JSON.stringify({
+    scope: 'subscribe',
+    timestamp: new Date().toISOString(),
+    ...payload
+  })
+
+  if (level === 'error') {
+    console.error(entry)
+    return
+  }
+
+  if (level === 'warn') {
+    console.warn(entry)
+    return
+  }
+
+  console.info(entry)
+}
+
+const getDurationMs = (startedAt: number) => Math.max(Date.now() - startedAt, 0)
+
+const getSubscribeSource = (value: unknown): SubscribeRequest['source'] | 'unknown' => {
+  if (value === 'home' || value === 'contact') {
+    return value
+  }
+
+  return 'unknown'
+}
+
+const getProviderErrorMetadata = (error: unknown) => {
+  if (!error || typeof error !== 'object') {
+    return {
+      providerCode: 'UNKNOWN_PROVIDER_ERROR',
+      providerStatusCode: undefined as number | undefined
+    }
+  }
+
+  const maybeError = error as {
+    name?: unknown
+    code?: unknown
+    statusCode?: unknown
+  }
+
+  return {
+    providerCode:
+      typeof maybeError.code === 'string'
+        ? maybeError.code
+        : typeof maybeError.name === 'string'
+          ? maybeError.name
+          : 'UNKNOWN_PROVIDER_ERROR',
+    providerStatusCode: typeof maybeError.statusCode === 'number' ? maybeError.statusCode : undefined
+  }
+}
+
+const respondFailure = (
+  event: H3Event,
+  startedAt: number,
+  requestId: string,
+  response: Omit<SubscribeFailureResponse, 'requestId' | 'ok'> & { httpStatus: number },
+  context: {
+    maskedEmail?: string
+    source?: string
+    providerCode?: string
+    providerStatusCode?: number
+    level?: SubscribeLogLevel
+  } = {}
+): SubscribeFailureResponse => {
+  const durationMs = getDurationMs(startedAt)
+  const retryAfterSeconds = response.retryAfterSeconds
+
+  setResponseStatus(event, response.httpStatus)
+  setResponseMetadata(event, requestId, response.status, durationMs, response.code, retryAfterSeconds)
+  logSubscribeEvent(context.level ?? 'warn', {
+    event: 'subscribe.failure',
+    requestId,
+    status: response.status,
+    code: response.code,
+    durationMs,
+    maskedEmail: context.maskedEmail,
+    source: context.source,
+    retryAfterSeconds,
+    providerCode: context.providerCode,
+    providerStatusCode: context.providerStatusCode
+  })
+
+  return {
+    ok: false,
+    requestId,
+    status: response.status,
+    code: response.code,
+    message: response.message,
+    retryable: response.retryable,
+    ...(typeof retryAfterSeconds === 'number' ? { retryAfterSeconds } : {})
+  }
+}
+
+const respondSuccess = (
+  event: H3Event,
+  startedAt: number,
+  requestId: string,
+  response: Omit<SubscribeSuccessResponse, 'requestId' | 'ok'>,
+  context: {
+    maskedEmail?: string
+    source?: string
+  } = {}
+): SubscribeSuccessResponse => {
+  const durationMs = getDurationMs(startedAt)
+
+  setResponseMetadata(event, requestId, response.status, durationMs)
+  logSubscribeEvent('info', {
+    event: 'subscribe.success',
+    requestId,
+    status: response.status,
+    durationMs,
+    maskedEmail: context.maskedEmail,
+    source: context.source
+  })
+
+  return {
+    ok: true,
+    requestId,
+    status: response.status,
+    message: response.message
+  }
+}
 
 export default defineEventHandler(async (event): Promise<SubscribeResponse> => {
+  const startedAt = Date.now()
+  const requestId = createRequestId()
   let body: Partial<SubscribeRequest> | null = null
 
   try {
     body = await readBody<Partial<SubscribeRequest>>(event)
   } catch {
-    setResponseStatus(event, 400)
-    return {
-      success: false,
-      message: 'Invalid request body.'
-    }
+    return respondFailure(
+      event,
+      startedAt,
+      requestId,
+      {
+        httpStatus: 400,
+        status: 'invalid',
+        code: 'SUBSCRIBE_INVALID_BODY',
+        message: 'Invalid request body.',
+        retryable: false
+      }
+    )
   }
 
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
-    setResponseStatus(event, 400)
-    return {
-      success: false,
-      message: 'Invalid request body.'
-    }
+    return respondFailure(
+      event,
+      startedAt,
+      requestId,
+      {
+        httpStatus: 400,
+        status: 'invalid',
+        code: 'SUBSCRIBE_INVALID_BODY',
+        message: 'Invalid request body.',
+        retryable: false
+      }
+    )
   }
 
   const email = typeof body?.email === 'string' ? body.email.trim().toLowerCase() : ''
   const maskedEmail = email ? maskEmail(email) : 'missing-email'
+  const source = getSubscribeSource(body?.source)
 
   if (!email) {
-    setResponseStatus(event, 400)
-    return {
-      success: false,
-      message: 'Email is required.'
-    }
+    return respondFailure(
+      event,
+      startedAt,
+      requestId,
+      {
+        httpStatus: 400,
+        status: 'invalid',
+        code: 'SUBSCRIBE_EMAIL_REQUIRED',
+        message: 'Email is required.',
+        retryable: false
+      },
+      {
+        maskedEmail,
+        source
+      }
+    )
+  }
+
+  if (email.length > MAX_EMAIL_LENGTH) {
+    return respondFailure(
+      event,
+      startedAt,
+      requestId,
+      {
+        httpStatus: 400,
+        status: 'invalid',
+        code: 'SUBSCRIBE_EMAIL_TOO_LONG',
+        message: 'Please enter a valid email address.',
+        retryable: false
+      },
+      {
+        maskedEmail,
+        source
+      }
+    )
   }
 
   if (!EMAIL_PATTERN.test(email)) {
-    setResponseStatus(event, 400)
-    return {
-      success: false,
-      message: 'Please enter a valid email address.'
-    }
+    return respondFailure(
+      event,
+      startedAt,
+      requestId,
+      {
+        httpStatus: 400,
+        status: 'invalid',
+        code: 'SUBSCRIBE_INVALID_EMAIL',
+        message: 'Please enter a valid email address.',
+        retryable: false
+      },
+      {
+        maskedEmail,
+        source
+      }
+    )
   }
 
   const now = Date.now()
@@ -106,36 +333,54 @@ export default defineEventHandler(async (event): Promise<SubscribeResponse> => {
   const lastAttemptAt = subscriptionThrottle.get(clientThrottleKey)
 
   if (typeof lastAttemptAt === 'number' && now - lastAttemptAt < SUBSCRIPTION_THROTTLE_WINDOW_MS) {
-    setResponseStatus(event, 429)
-    return {
-      success: false,
-      message: SUBSCRIPTION_THROTTLED_MESSAGE
-    }
+    const retryAfterSeconds = toRetryAfterSeconds(getRetryAfterMs(now, lastAttemptAt))
+
+    return respondFailure(
+      event,
+      startedAt,
+      requestId,
+      {
+        httpStatus: 429,
+        status: 'throttled',
+        code: 'SUBSCRIBE_THROTTLED',
+        message: SUBSCRIPTION_THROTTLED_MESSAGE,
+        retryable: true,
+        retryAfterSeconds
+      },
+      {
+        maskedEmail,
+        source
+      }
+    )
   }
 
+  subscriptionThrottle.set(clientThrottleKey, now)
+
   const runtimeConfig = useRuntimeConfig(event)
-  const resendApiKey = pickRuntimeString(
-    runtimeConfig.resendApiKey,
-    runtimeConfig.NUXT_RESEND_API_KEY,
-    process.env.RESEND_API_KEY
-  )
-  const resendFromEmail = pickRuntimeString(
-    runtimeConfig.resendFromEmail,
-    runtimeConfig.NUXT_RESEND_FROM_EMAIL,
-    process.env.RESEND_FROM_EMAIL
-  )
+  const resendApiKey = pickRuntimeString(runtimeConfig.resendApiKey)
+  const resendFromEmail = pickRuntimeString(runtimeConfig.resendFromEmail)
 
   if (!resendApiKey || resendApiKey === RESEND_API_KEY_PLACEHOLDER || !resendFromEmail) {
-    setResponseStatus(event, 503)
-    return {
-      success: false,
-      message: SUBSCRIPTION_UNAVAILABLE_MESSAGE
-    }
+    return respondFailure(
+      event,
+      startedAt,
+      requestId,
+      {
+        httpStatus: 503,
+        status: 'unavailable',
+        code: 'SUBSCRIBE_CONFIG_MISSING',
+        message: SUBSCRIPTION_UNAVAILABLE_MESSAGE,
+        retryable: true
+      },
+      {
+        maskedEmail,
+        source,
+        level: 'error'
+      }
+    )
   }
 
   try {
-    subscriptionThrottle.set(clientThrottleKey, now)
-
     const resend = new Resend(resendApiKey)
     const idempotencyKey = await createSubscriptionIdempotencyKey(email)
 
@@ -147,29 +392,83 @@ export default defineEventHandler(async (event): Promise<SubscribeResponse> => {
     )
 
     if (error) {
-      setResponseStatus(event, 502)
-      return {
-        success: false,
-        message: SUBSCRIPTION_FAILED_MESSAGE
-      }
+      const { providerCode, providerStatusCode } = getProviderErrorMetadata(error)
+
+      return respondFailure(
+        event,
+        startedAt,
+        requestId,
+        {
+          httpStatus: 502,
+          status: 'failed',
+          code: 'SUBSCRIBE_PROVIDER_REJECTED',
+          message: SUBSCRIPTION_FAILED_MESSAGE,
+          retryable: true
+        },
+        {
+          maskedEmail,
+          source,
+          providerCode,
+          providerStatusCode,
+          level: 'error'
+        }
+      )
     }
 
     if (!data) {
-      setResponseStatus(event, 502)
-      return {
-        success: false,
-        message: SUBSCRIPTION_FAILED_MESSAGE
-      }
+      return respondFailure(
+        event,
+        startedAt,
+        requestId,
+        {
+          httpStatus: 502,
+          status: 'failed',
+          code: 'SUBSCRIBE_PROVIDER_NO_DATA',
+          message: SUBSCRIPTION_FAILED_MESSAGE,
+          retryable: true
+        },
+        {
+          maskedEmail,
+          source,
+          level: 'error'
+        }
+      )
     }
 
-    return {
-      success: true
-    }
+    return respondSuccess(
+      event,
+      startedAt,
+      requestId,
+      {
+        status: 'accepted',
+        message: SUBSCRIBE_ACCEPTED_MESSAGE
+      },
+      {
+        maskedEmail,
+        source
+      }
+    )
   } catch (error) {
-    setResponseStatus(event, 502)
-    return {
-      success: false,
-      message: SUBSCRIPTION_UNAVAILABLE_MESSAGE
-    }
+    const { providerCode, providerStatusCode } = getProviderErrorMetadata(error)
+
+    return respondFailure(
+      event,
+      startedAt,
+      requestId,
+      {
+        httpStatus: 502,
+        status: 'unavailable',
+        code: 'SUBSCRIBE_PROVIDER_EXCEPTION',
+        message: SUBSCRIPTION_UNAVAILABLE_MESSAGE,
+        retryable: true
+      },
+      {
+        maskedEmail,
+        source,
+        providerCode,
+        providerStatusCode,
+        level: 'error'
+      }
+    )
   }
 })

--- a/server/services/email/subscription.ts
+++ b/server/services/email/subscription.ts
@@ -4,9 +4,18 @@ const confirmationBody = [
   '<p>We appreciate your interest in our learning paths and community.</p>'
 ].join('')
 
+const confirmationText = [
+  'Thank you for your interest in Skill Wanderer.',
+  '',
+  'This email confirms that we received your request.',
+  '',
+  'We appreciate your interest in our learning paths and community.'
+].join('\n')
+
 export const createSubscriptionConfirmationEmail = (email: string, fromEmail: string) => ({
   from: `Skill Wanderer <${fromEmail}>`,
   to: [email],
   subject: 'Welcome to Skill Wanderer',
-  html: confirmationBody
+  html: confirmationBody,
+  text: confirmationText
 })

--- a/types/index.ts
+++ b/types/index.ts
@@ -41,15 +41,39 @@ export interface PracticeExample {
 
 export interface SubscribeRequest {
   email: string
+  source?: 'home' | 'contact'
 }
+
+export type SubscribeSuccessStatus = 'accepted' | 'confirmed'
+
+export type SubscribeFailureStatus = 'invalid' | 'throttled' | 'unavailable' | 'failed'
+
+export type SubscribeFailureCode =
+  | 'SUBSCRIBE_INVALID_BODY'
+  | 'SUBSCRIBE_EMAIL_REQUIRED'
+  | 'SUBSCRIBE_INVALID_EMAIL'
+  | 'SUBSCRIBE_EMAIL_TOO_LONG'
+  | 'SUBSCRIBE_THROTTLED'
+  | 'SUBSCRIBE_CONFIG_MISSING'
+  | 'SUBSCRIBE_PROVIDER_REJECTED'
+  | 'SUBSCRIBE_PROVIDER_NO_DATA'
+  | 'SUBSCRIBE_PROVIDER_EXCEPTION'
 
 export type SubscribeResponse =
   | {
-      success: true
+      ok: true
+      status: SubscribeSuccessStatus
+      message: string
+      requestId: string
     }
   | {
-      success: false
+      ok: false
+      status: SubscribeFailureStatus
+      code: SubscribeFailureCode
       message: string
+      requestId: string
+      retryable: boolean
+      retryAfterSeconds?: number
     }
 
 // Extend global types if needed


### PR DESCRIPTION
# Summary

Stabilizes the newsletter subscribe workflow by improving:
- runtime resilience
- degraded-state handling
- observability
- timeout handling
- workflow-state semantics
- provider error handling

# Key Improvements

- Added explicit subscribe workflow states
- Added AbortController timeout handling
- Added reload interruption recovery
- Added request correlation metadata
- Added retry metadata support
- Hardened throttle behavior during degraded runtime states
- Improved provider failure categorization
- Improved operational telemetry surfaces

# Validation

- npm run typecheck ✅
- npm run build ✅
- Local subscribe flow validated
- Timeout flow validated
- Reload interruption recovery validated
- Invalid provider credential path validated

# Important Notes

- docs/ intentionally excluded from this PR
- production deployment still required
- public smoke test still required after deployment
- runtime env bindings must be verified in deployment platform

# Remaining Follow-Up

- Deploy current branch
- Verify NUXT_RESEND_API_KEY
- Verify NUXT_RESEND_FROM_EMAIL
- Run production smoke test